### PR TITLE
Changed opacity example in docs

### DIFF
--- a/_pages/learn/colors.md
+++ b/_pages/learn/colors.md
@@ -51,7 +51,7 @@ Additionally, use `'random'` to produce a random color value.
 Change the opacity, or transparency, of an object by using the `opacity` method:
 
 ```ruby
-square.opacity = 0.5
+square.color.opacity = 0.5
 ```
 
 Continue to the [next topic ▸](/learn/{{ page.next_topic }})


### PR DESCRIPTION
I was using the docs to find how to change the opacity of a square, but when I followed the docs I got an error that `opacity` does not exit on object of type `Square`. Found out you have to call `sqaure.color.opacity` instead, which I changed in the docs.